### PR TITLE
Added `options.text`; updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,58 @@
-## Information
+## gulp-mail
 
-<table>
-  <tr>
-    <td>Package</td><td>gulp-mail</td>
-  </tr>
-  <tr>
-    <td>Description</td>
-    <td>Send mails with gulp</td>
-  </tr>
-</table>
+A [gulp](https://github.com/gulpjs/gulp) wrapper for [Nodemailer](https://nodemailer.com) used to quickly send emails from tasks and/or the command-line during development or testing.
 
-Highly learnt from [gulp-mailer](https://github.com/meerkats/gulp-mailer) (not available on npm)
+`gulp-mail` is based on [gulp-mailer](https://github.com/meerkats/gulp-mailer), which is not available on [npm](https://www.npmjs.com/).
 
-## Usage
+### Installation
 
-### `mail(options)`
+Installing via [npm](https://www.npmjs.org/package/gulp-mail):
 
-- options: [object]
+```sh
+npm install --save-dev gulp-mail
+```
+
+### Usage
+
+#### `mail(options)`
+- options: `Object`
+
+### Options
+
+`gulp-mail` uses Nodemailer v0.7.1, which has been deprecated for some time. It is, however, simple and stable. Available options for `gulp-mail` are:
+
+##### options.smtp
+Type: `Object`  
+Contains required SMTP configuration values. (See the example below.)
+
+##### options.to
+Type: `String|Array`  
+A string or array containing one or more than one recipient address, respectively.
+
+##### options.from
+Type: `String`  
+The display name for the sender.
+
+##### options.subject
+Type: `String`  
+The email subject line. If not provided, a default subject line is generated from the source filename as `[TEST] path.basename`.
+
+##### options.html
+Type: `String`  
+The HTML body of the email. If not provided, the source file becomes the message body.
+
+##### options.text
+Type: `String`  
+The plaintext body of the email. If not provided, Nodemailer generates this based on the source file.
+
+### Example
+
+Currently, `gulp-mail` takes in piped streams and sends emails via SMTP only.
 
 ```js
-var mail = require('gulp-mail')
+var gulp = require('gulp');
+var mail = require('gulp-mail');
+
 var smtpInfo = {
   auth: {
     user: 'foo@163.com',
@@ -28,10 +61,10 @@ var smtpInfo = {
   host: 'smtp.163.com',
   secureConnection: true,
   port: 465
-}
+};
 
-gulp.task('mail', function() {
-  return gulp.src('./mails/i-love-you.html')
+gulp.task('mail', function () {
+  return gulp.src('./mails/i-love-you.html');
     .pipe(mail({
       subject: 'Surprise!?',
       to: [
@@ -39,6 +72,6 @@ gulp.task('mail', function() {
       ],
       from: 'Foo <foo@163.com>',
       smtp: smtpInfo
-    }))
-})
+    }));
+});
 ```

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function (options) {
         from: null,
         subject: null,
         html: null,
+        text: null,
         smtp: null
     });
 
@@ -30,13 +31,15 @@ module.exports = function (options) {
         var to = options.to.join(',');
         var subject = options.subject || _subjectFromFilename(file.path);
         var html = options.html || file.contents.toString();
+        var text = options.text || null;
 
         return transporter.sendMail({
             from: options.from,
             to: to,
             subject: subject,
             generateTextFromHTML: true, // added
-            html: html
+            html: html,
+            text: text
         }, function (error, info) {
 
             if (error) {


### PR DESCRIPTION
This PR adds support for specifying the plaintext of an email. Also added documentation for all available options.